### PR TITLE
Add DESTDIR to the build env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ IHTMLS		 = db.txt.html \
 		   db.old.txt.html \
 		   db.update.sql.html \
 		   db.js.html \
-		   test.c.html 
+		   test.c.html
 
 kwebapp: $(OBJS)
 	$(CC) -o $@ $(OBJS)
@@ -188,7 +188,7 @@ TODO.xml: TODO.md
 	  echo "</article>" ; ) >$@
 
 clean:
-	rm -f kwebapp $(OBJS) db.c db.h db.o db.sql db.js db.update.sql db.db test test.o 
+	rm -f kwebapp $(OBJS) db.c db.h db.o db.sql db.js db.update.sql db.db test test.o
 	rm -f kwebapp.tar.gz kwebapp.tar.gz.sha512
 	rm -f index.svg index.html highlight.css kwebapp.5.html kwebapp.1.html
 	rm -f db.txt.xml db.h.xml db.sql.xml db.update.sql.xml test.xml.xml $(IHTMLS) TODO.xml

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,12 @@ installwww: www
 	install -m 0444 kwebapp.tar.gz.sha512 $(WWWDIR)/snapshots/kwebapp-$(VERSION).tar.gz.sha512
 
 install: kwebapp
-	mkdir -p $(BINDIR)
-	mkdir -p $(MANDIR)/man1
-	mkdir -p $(MANDIR)/man5
-	$(INSTALL_PROGRAM) kwebapp $(BINDIR)
-	$(INSTALL_MAN) kwebapp.1 $(MANDIR)/man1
-	$(INSTALL_MAN) kwebapp.5 $(MANDIR)/man5
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	mkdir -p $(DESTDIR)$(MANDIR)/man5
+	$(INSTALL_PROGRAM) kwebapp $(DESTDIR)$(BINDIR)
+	$(INSTALL_MAN) kwebapp.1 $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL_MAN) kwebapp.5 $(DESTDIR)$(MANDIR)/man5
 
 kwebapp.tar.gz.sha512: kwebapp.tar.gz
 	sha512 kwebapp.tar.gz >$@

--- a/configure
+++ b/configure
@@ -17,7 +17,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# 
+#
 # This script outputs two files: config.h and Makefile.configure.
 # It tries to read from configure.local, which contains predefined
 # values we won't autoconfigure.
@@ -84,7 +84,7 @@ INSTALL_DATA=
 # Allow certain variables to be overriden on the command line.
 #----------------------------------------------------------------------
 
-for keyvals in $@ 
+for keyvals in $@
 do
 	key=`echo $keyvals | cut -s -d '=' -f 1`
 	if [ -z "$key" ]
@@ -154,7 +154,7 @@ HAVE_SYSTRACE=
 HAVE___PROGNAME=
 
 #----------------------------------------------------------------------
-# Allow configure.local to override all variables, default settings, 
+# Allow configure.local to override all variables, default settings,
 # command-line arguments, and tested features, above.
 # You PROBABLY DO NOT want to change this.
 #----------------------------------------------------------------------

--- a/configure
+++ b/configure
@@ -66,6 +66,7 @@ CFLAGS="${CFLAGS} -Wwrite-strings -Wno-unused-parameter"
 LDADD=
 CPPFLAGS=
 LDFLAGS=
+DESTDIR=
 PREFIX="/usr/local"
 BINDIR=
 SBINDIR=
@@ -97,6 +98,8 @@ do
 		LDFLAGS="$val" ;;
 	CPPFLAGS)
 		CPPFLAGS="$val" ;;
+	DESTDIR)
+		DESTDIR="$val" ;;
 	PREFIX)
 		PREFIX="$val" ;;
 	MANDIR)


### PR DESCRIPTION
This lets the OpenBSD ports framework install to `$(DESTDIR)$(PREFIX)` for building a package.

Also cleans up some trailing whitespace.